### PR TITLE
Firefox datepicker opening fix

### DIFF
--- a/src/lib/DateTimeRangeContainer.jsx
+++ b/src/lib/DateTimeRangeContainer.jsx
@@ -129,7 +129,7 @@ class DateTimeRangeContainer extends React.Component {
         }}
       >
         {this.props.children && (
-          <div id="DateRangePickerChildren">{this.props.children}</div>
+          <div id="DateRangePickerChildren" className="pointer-events-none">{this.props.children}</div>
         )}
         <div
           id="daterangepicker"


### PR DESCRIPTION
Hello @mohsentaleb, I have fixed https://github.com/v0ltoz/react-datetimepicker/issues/60 by using `pointer-events: none` to prevent `onClick` event propagation to the children nodes.