### PR TITLE
Fix the cancel button applying the changes

### DIFF
--- a/src/lib/date_picker/ApplyCancelButtons.tsx
+++ b/src/lib/date_picker/ApplyCancelButtons.tsx
@@ -104,8 +104,8 @@ export default class ApplyCancelButtons extends React.Component<Props> {
           this.props.classNames?.cancelButton
         )}
         type="button"
-        onClick={this.applyPressed}
-        onKeyDown={this.applyOnKeyPress}
+        onClick={this.cancelPressed}
+        onKeyDown={this.cancelOnKeyPress}
         tabIndex={0}
       >
         {closeButtonText}


### PR DESCRIPTION
The cancel button was using the apply button's handles. This change fixes it to use the already defined `cancelPressed` and `cancelOnKeyPress` handles